### PR TITLE
tests: fix test_badssl_no_built_in_roots

### DIFF
--- a/tests/badssl.rs
+++ b/tests/badssl.rs
@@ -69,7 +69,7 @@ async fn test_badssl_no_built_in_roots() {
         .no_proxy()
         .build()
         .unwrap()
-        .get("https://mozilla-modern.badssl.com/")
+        .get("https://untrusted-root.badssl.com/") 
         .send()
         .await;
 


### PR DESCRIPTION
```rust
     Running tests/badssl.rs (target/debug/deps/badssl-7143a8110a644dbf)

running 3 tests
test test_badssl_modern ... ok
test test_badssl_no_built_in_roots ... FAILED
test test_badssl_self_signed ... ok

failures:

---- test_badssl_no_built_in_roots stdout ----
thread 'test_badssl_no_built_in_roots' panicked at 'assertion failed: result.is_err()', tests/badssl.rs:76:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test_badssl_no_built_in_roots

test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.73s
```