### PR TITLE
[BugFix] Correct `Content-Type` header for form data submission

### DIFF
--- a/src/blocking/request.rs
+++ b/src/blocking/request.rs
@@ -443,7 +443,7 @@ impl RequestBuilder {
                 Ok(body) => {
                     if !req.headers().contains_key(CONTENT_TYPE) {
                         req.headers_mut()
-                            .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+                            .insert(CONTENT_TYPE, HeaderValue::from_static("application/x-www-form-urlencoded"));
                     }
                     *req.body_mut() = Some(body.into());
                 }


### PR DESCRIPTION
Bugfix in `blocking::request::RequestBuilder.form()`.

Content-Type header was incorrectly set for form data submissions - `application/json`.
Changed to `application/x-www-form-urlencoded`.