### PR TITLE
fix(client): Fix http version setting order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-default = ["boring-tls", "http2"]
+default = ["boring-tls"]
 
 full = [
     "boring-tls",
@@ -31,11 +31,8 @@ full = [
     "stream",
     "cookies",
     "socks",
-    "http2",
     "hickory-dns",
 ]
-
-http2 = ["h2", "hyper/http2"]
 
 blocking = ["futures-util/io", "tokio/sync"]
 
@@ -76,6 +73,7 @@ boring-tls = [
     "dep:linked_hash_set",
     "dep:tower-layer",
     "dep:antidote",
+    "dep:typed-builder"
 ]
 
 # When enabled, disable using the cached SYS_PROXIES.
@@ -104,10 +102,11 @@ http-body = "0.4.6"
 hyper = { package = "rhyper", version = "0.14", default-features = false, features = [
     "tcp",
     "http1",
+    "http2",
     "client",
     "runtime",
 ] }
-h2 = { package = "rh2", version = "0.3", optional = true }
+h2 = { package = "rh2", version = "0.3" }
 log = "0.4"
 mime = "0.3.17"
 percent-encoding = "2.3"
@@ -130,6 +129,9 @@ libc = { version = "0.2", optional = true }
 linked_hash_set = { version = "0.1", optional = true }
 tower-layer = { version = "0.3", optional = true }
 antidote = { version = "1", optional = true }
+
+# boring-tls extension builder
+typed-builder = { version = "0.19", optional = true }
 
 ## cookies
 cookie_crate = { version = "0.18", package = "cookie", optional = true }

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -19,7 +19,7 @@ use crate::tls::{Impersonate, TlsSettings, Version};
 use crate::{async_impl, header, redirect, IntoUrl, Method, Proxy};
 #[cfg(feature = "boring-tls")]
 use header::HeaderMap;
-#[cfg(feature = "http2")]
+#[cfg(feature = "boring-tls")]
 use hyper::{PseudoOrder, SettingsOrder, StreamDependency};
 
 /// A `Client` to make Requests with.
@@ -582,7 +582,6 @@ impl ClientBuilder {
     /// Sets the pseudo header order for HTTP2.
     /// This is an array of 4 elements, each element is a `PseudoOrder` enum.
     /// Default is `None`.
-    #[cfg(feature = "http2")]
     pub fn http2_headers_pseudo_order(
         self,
         order: impl Into<Option<[PseudoOrder; 4]>>,
@@ -592,7 +591,6 @@ impl ClientBuilder {
 
     /// Sets the priority for HTTP2 headers.
     /// Default is `None`.
-    #[cfg(feature = "http2")]
     pub fn http2_headers_priority(
         self,
         priority: impl Into<Option<StreamDependency>>,
@@ -603,7 +601,6 @@ impl ClientBuilder {
     /// Sets the settings order for HTTP2.
     /// This is an array of 2 elements, each element is a `SettingsOrder` enum.
     /// Default is `None`.
-    #[cfg(feature = "http2")]
     pub fn http2_settings_order(
         self,
         order: impl Into<Option<[SettingsOrder; 2]>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,7 +359,7 @@ pub use self::async_impl::{
 };
 pub use self::proxy::{NoProxy, Proxy};
 
-#[cfg(all(feature = "boring-tls", feature = "http2"))]
+#[cfg(feature = "boring-tls")]
 pub use hyper::{PseudoOrder, SettingsOrder, StreamDependency, StreamId};
 
 mod async_impl;

--- a/src/tls/builder.rs
+++ b/src/tls/builder.rs
@@ -251,7 +251,6 @@ impl TlsExtension for SslConnectorBuilder {
             HttpVersionPref::Http1 => {
                 self.set_alpn_protos(b"\x08http/1.1")?;
             }
-            #[cfg(feature = "http2")]
             HttpVersionPref::Http2 => {
                 self.set_alpn_protos(b"\x02h2")?;
             }
@@ -363,10 +362,7 @@ impl TlsConnectExtension for ConnectConfiguration {
 
         let (alpn, alpn_len) = match http_version {
             HttpVersionPref::Http1 => ("http/1.1", 8),
-            #[cfg(feature = "http2")]
             HttpVersionPref::Http2 | HttpVersionPref::All => ("h2", 2),
-            #[cfg(not(feature = "http2"))]
-            HttpVersionPref::All => ("http/1.1", 8),
         };
 
         unsafe {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Removed default support for HTTP/2, requiring manual enabling for clients that need it.
  - Added a new optional dependency (`typed-builder`) for improved configuration management in the `boring-tls` context.

- **Bug Fixes**
  - Streamlined client configuration by removing deprecated HTTP/2 settings, enhancing overall usability.

- **Documentation**
  - Updated the conditions for exporting certain types from the `hyper` module to simplify usage requirements.

- **Chores**
  - Cleaned up codebase by removing conditional compilation flags related to HTTP/2, focusing on HTTP/1.1 defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->